### PR TITLE
Fix temperature conversion

### DIFF
--- a/mideaAC_localController
+++ b/mideaAC_localController
@@ -544,10 +544,10 @@ def correctTemp(input, inputScale)
     switch(inputScale)
     {
         case "F":
-            return (degC ? fahrenheitToCelsius(new BigDecimal(input)) : (Math.round(new BigDecimal(input) * 2) / 2).setScale(1, BigDecimal.ROUND_HALF_UP))
+            return (degC ? (Math.round(fahrenheitToCelsius(new BigDecimal(input)) * 2) / 2).setScale(1, BigDecimal.ROUND_HALF_UP) : new BigDecimal(input))
         
         case "C":
-            return (degC ? new BigDecimal(input) : (Math.round(celsiusToFahrenheit(new BigDecimal(input)) * 2) / 2).setScale(1, BigDecimal.ROUND_HALF_UP))
+            return (degC ? new BigDecimal(input) : (new BigDecimal(Math.round(celsiusToFahrenheit(new BigDecimal(input))))).setScale(1, BigDecimal.ROUND_HALF_UP))
         
         default:
             return input
@@ -556,7 +556,7 @@ def correctTemp(input, inputScale)
 
 def ensureCelsius(input)
 {
-    return (degC) ? new BigDecimal(input) : fahrenheitToCelsius(new BigDecimal(input))
+    return (degC) ? new BigDecimal(input) : (Math.round(fahrenheitToCelsius(new BigDecimal(input)) * 2) / 2).setScale(1, BigDecimal.ROUND_HALF_UP)
 }
 
 def _updateAttributes(resp)


### PR DESCRIPTION
The temperature conversion from C to F has given me strange behavior. It always reported the temperature as 0.5F lower than what was set, and attempting to set some temperatures would result in no change. Looking into it, the AC unit works in 0.5 degree C increments, so I updated the conversion functions to do the following:
- C to F - Round to the nearest 1.0F
- F to C - Round to the nearest 0.5C

When the driver is working in C, none of this really matters because there isn't any conversion being done, so the values are set and returned directly.